### PR TITLE
Fix for organism_check() and get_collectri()

### DIFF
--- a/R/utils-omnipath.R
+++ b/R/utils-omnipath.R
@@ -443,7 +443,7 @@ check_organism <- function(organism) {
     )
   if (!ncbi_tax_id %in% c(9606L, 10090L, 10116L)){
     stop(sprintf(
-      "Organism can only be human or mouse or rat, `%s` provided.",
+      "Organism can only be human or mouse or rat (rnorvegicus), `%s` provided.",
       ncbi_tax_id
     ))
   }


### PR DESCRIPTION
As referenced in #164 the get_collectri() function does not accept the argument "rat" for `organism`. It has to be `rnorvegicus`. I have change this in the error message, but this needs to also be changed across the package and documentation.
